### PR TITLE
Add Open Color and Callisto themes

### DIFF
--- a/themes/callisto.intersectstyle
+++ b/themes/callisto.intersectstyle
@@ -1,0 +1,50 @@
+# INTERSECT Callisto theme
+#
+# Themes folder:
+#   Windows:  %APPDATA%\Roaming\INTERSECT\themes\
+#   macOS:    ~/Library/Application Support/INTERSECT/themes/
+#   Linux:    ~/.config/INTERSECT/themes/
+#
+# Colours are 6-digit hex (RRGGBB). Restart the plugin to apply changes.
+
+name: callisto
+
+# Main surfaces
+background: 262833          # window background
+waveformBg: 161b21          # waveform area background
+darkBar: 161b21             # slice control bar / action panel background
+header: 161b21              # header bar background
+
+# Text & lines
+foreground: d1e0ef          # primary text colour
+gridLine: 5e6d7c            # waveform grid lines
+separator: 5e6d7c           # horizontal separator lines
+
+# Waveform & slices
+waveform: 00a08d            # waveform draw colour
+selectionOverlay: 00e1c6    # selected slice translucent overlay
+
+# Controls
+accent: 00d0b8              # accent colour (labels, highlights)
+lockActive: 00d0b8          # locked/overridden parameter indicator
+lockInactive: 5e6d7c        # unlocked/inherited parameter indicator
+button: 262833              # button background
+buttonHover: 5e6d7c         # button hover background
+
+# Slice palette (colours assigned to new slices)
+slice1: 8f9fae              # 
+slice2: 5e6d7c              # 
+slice3: 8f9fae              # 
+slice4: 5e6d7c              # 
+slice5: 8f9fae              # 
+slice6: 5e6d7c              # 
+slice7: 8f9fae              # 
+slice8: 5e6d7c              # 
+slice9: 8f9fae              # 
+slice10: 5e6d7c             # 
+slice11: 8f9fae             # 
+slice12: 5e6d7c             # 
+slice13: 8f9fae             # 
+slice14: 5e6d7c             # 
+slice15: 8f9fae             # 
+slice16: 5e6d7c             # 

--- a/themes/oc.intersectstyle
+++ b/themes/oc.intersectstyle
@@ -1,0 +1,51 @@
+# INTERSECT Open Color's inspired theme
+# Source: https://github.com/yeun/open-color
+#
+# Themes folder:
+#   Windows:  %APPDATA%\Roaming\INTERSECT\themes\
+#   macOS:    ~/Library/Application Support/INTERSECT/themes/
+#   Linux:    ~/.config/INTERSECT/themes/
+#
+# Colours are 6-digit hex (RRGGBB). Restart the plugin to apply changes.
+
+name: oc
+
+# Main surfaces
+background: 212529          # window background
+waveformBg: 191C1F          # waveform area background
+darkBar: 212529             # slice control bar / action panel background
+header: 212529              # header bar background
+
+# Text & lines
+foreground: ced4da          # primary text colour
+gridLine: 343a40            # waveform grid lines
+separator: 495057           # horizontal separator lines
+
+# Waveform & slices
+waveform: adb5bd            # waveform draw colour
+selectionOverlay: 66a80f    # selected slice translucent overlay
+
+# Controls
+accent: 82c91e              # accent colour (labels, highlights)
+lockActive: ff922b          # locked/overridden parameter indicator
+lockInactive: 495057        # unlocked/inherited parameter indicator
+button: 343a40              # button background
+buttonHover: 495057         # button hover background
+
+# Slice palette (colours assigned to new slices)
+slice1: ffa8a8              # 
+slice2: e599f7              # 
+slice3: 91a7ff              # 
+slice4: 66d9e8              # 
+slice5: 8ce99a              # 
+slice6: ffe066              # 
+slice7: ff6b6b              # 
+slice8: cc5de8              # 
+slice9: faa2c1              # 
+slice10: b197fc             # 
+slice11: 74c0fc             # 
+slice12: 63e6be             # 
+slice13: c0eb75             # 
+slice14: ffc078             # 
+slice15: f06595             # 
+slice16: 845ef7             # 


### PR DESCRIPTION
Screenshots:
Opencolor
<img width="1125" height="688" alt="oc" src="https://github.com/user-attachments/assets/b23e4e46-a89c-4c3f-a4b0-ec1e2414531e" />

Callisto
<img width="1125" height="688" alt="callisto" src="https://github.com/user-attachments/assets/565b6656-9436-43ab-ad5e-6382a2ccece4" />
