### PR TITLE
feat: automatic per-sample BPM detection (MiniBPM)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "signalsmith-linear"]
 	path = signalsmith-linear
 	url = https://github.com/Signalsmith-Audio/linear.git
+[submodule "minibpm"]
+	path = minibpm
+	url = https://github.com/breakfastquay/minibpm.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Automatic BPM detection: a `BPM` button on each sample detects that sample's tempo (with a tap-to-confirm menu of the best estimate plus half/double alternatives), plus an optional setting (gear menu → Auto-Detect BPM on Import) to detect BPM automatically for imported samples.
+- Each sample now remembers its own BPM; slices follow their sample's tempo unless individually locked.
+
+### Changed
+- The signal chain's `GLOBAL` tab is now `SAMPLE`, reflecting that its parameters apply to the loaded sample.
+
 ## [0.15.3] - 2026-07-23
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,8 @@ target_sources(Intersect PRIVATE
     src/ui/AutoChopPanel.cpp
     src/ui/StemExportPanel.cpp
     src/audio/StemSeparationJob.cpp
+    src/audio/BpmDetector.cpp
+    minibpm/src/MiniBpm.cpp
 )
 
 target_include_directories(Intersect PRIVATE

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Requires CMake 3.22+, a C++20 compiler, and Git. For per-OS toolchain setup, bui
 
 INTERSECT is licensed under the [GNU General Public License v3.0](LICENSE).
 
+Automatic BPM detection uses [MiniBPM](https://github.com/breakfastquay/minibpm) © Particular Programs Ltd., distributed under the GNU General Public License v2 or later (compatible with this project's GPLv3).
+
 ## Support / Known limitations
 
 - INTERSECT project recall stores sample file paths for every file in the session; if files move, relink is required.

--- a/docs/controls-reference.md
+++ b/docs/controls-reference.md
@@ -97,7 +97,7 @@ Filter notes:
 | `MUTE` | Mute group | `0–32`, `0` = off. Voices in the same group choke each other |
 | `1SHOT` | One-shot playback | Ignores note-off until the slice ends |
 | `OUT` | Output bus | `SLICE` mode only, `1` to `16` |
-| `VOICES` | Max playable voices | `GLOBAL` mode only, `1` to `31` (voice 32 is reserved for the preview voice) |
+| `VOICES` | Max playable voices | `SAMPLE` mode only, `1` to `31` (voice 32 is reserved for the preview voice) |
 
 ## Master and global controls
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,7 +41,7 @@ If nothing plays, see [Troubleshooting → A slice doesn't make sound]({{ site.b
 
 ## 4. Adjust a slice parameter (and see how locking works)
 
-The bottom of the editor is the **signal chain bar**. It has two tabs: `GLOBAL` (sample-wide defaults) and `SLICE` (overrides for the selected slice).
+The bottom of the editor is the **signal chain bar**. It has two tabs: `SAMPLE` (sample-wide defaults) and `SLICE` (overrides for the selected slice).
 
 1. Click your slice on the waveform to select it.
 2. In the signal chain bar, click the `SLICE` tab.
@@ -49,7 +49,7 @@ The bottom of the editor is the **signal chain bar**. It has two tabs: `GLOBAL` 
 
 The parameter label highlights — that means the slice has a locked override on `PITCH`. Right-click the value (or click the highlighted label) to clear the lock and inherit the global default again.
 
-This is INTERSECT's core idea: edit defaults in `GLOBAL`, then lock per-slice overrides where you want them to differ.
+This is INTERSECT's core idea: edit defaults in `SAMPLE`, then lock per-slice overrides where you want them to differ.
 
 ## 5. Chop the sample into even pieces
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -20,7 +20,7 @@ description: "Tour of every visible area of the INTERSECT editor — header bar,
 
 | Area | Function | Notes |
 | --- | --- | --- |
-| Sample lane | Compact session-sample overview above the slice lane | Reflects selection and zoom; drag to reorder samples; includes per-sample `STEMS` / `CANCEL` and delete buttons |
+| Sample lane | Compact session-sample overview above the slice lane | Reflects selection and zoom; drag to reorder samples; includes per-sample `BPM` (detect tempo), `STEMS` / `CANCEL`, and delete buttons |
 | Slice lane | Compact slice-region overview above the waveform | Reflects selection and zoom |
 | Waveform | Main editing surface | Drag-and-drop loading/appending, slice selection, boundary editing, move/duplicate, preview |
 | Overlay hints | Contextual help and action prompts | Used by `ADD`, `AUTO`, and other actions |
@@ -46,6 +46,8 @@ Loading behavior matches the rest of INTERSECT: into an empty session, the first
 ## Stem separation
 
 Each sample in the sample lane has a `STEMS` button that opens the stem-separation overlay panel for that sample. While a job is running on that sample, the button reads `CANCEL`.
+
+Each sample also has a `BPM` button (to the left of `STEMS`) that detects that sample's tempo and sets its Sample BPM. On narrow blocks the label collapses to `B`, and it shows `…` while detection runs. See [Detect BPM](workflow-basics.md#detect-bpm) for the full workflow.
 
 For an end-to-end walkthrough — picking a model, device, and mode, then running the export — see the dedicated [Stem separation]({{ site.baseurl }}{% link stem-separation.md %}) page.
 
@@ -74,16 +76,18 @@ For an end-to-end walkthrough — picking a model, device, and mode, then runnin
 
 The bottom bar is the main parameter editor. It has four modules: `TIME/PITCH`, `FILTER`, `AMP`, and `PLAYBACK`.
 
-**Collapsed mode** (default): `GLOBAL` and `SLICE` tabs switch between scopes, with one parameter strip visible at a time.
+**Collapsed mode** (default): `SAMPLE` and `SLICE` tabs switch between scopes, with one parameter strip visible at a time.
 
-**Expanded mode**: shows both strips simultaneously — slice on top, global below — with no tabs. Click the chevron toggle on the right edge of the context bar to switch between modes.
+**Expanded mode**: shows both strips simultaneously — slice on top, sample below — with no tabs. Click the chevron toggle on the right edge of the context bar to switch between modes.
+
+> Note: in the `SAMPLE` strip, `BPM` is stored **per sample** — each loaded sample keeps its own tempo. The other `SAMPLE` fields (pitch, envelope, filter, etc.) are shared plugin-wide defaults.
 
 **Context bar** (bottom edge):
 - `SLICES` count and the global `ROOT` note are always visible on the right. The global `ROOT` is editable only when no slices exist.
 - When a slice is selected: slice sample range, length, a `NOTE`/`RANGE` toggle, numeric note controls, read-only note names, and override count.
 
 ```text
-┌─[ Tab: GLOBAL | SLICE ]─────────[ slice range · length · NOTE/RANGE ]──────[ SLICES: 8  ROOT: C2 ]──[ ⌃ ]─┐
+┌─[ Tab: SAMPLE | SLICE ]─────────[ slice range · length · NOTE/RANGE ]──────[ SLICES: 8  ROOT: C2 ]──[ ⌃ ]─┐
 │  TIME/PITCH        │  FILTER             │  AMP               │  PLAYBACK                                  │
 │  BPM PITCH ALGO …  │  TYPE CUT RESO …    │  ATK DEC SUS REL … │  REV LOOP FADE MUTE OUT …                  │
 └────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

--- a/docs/workflow-basics.md
+++ b/docs/workflow-basics.md
@@ -39,11 +39,11 @@ Range mode is what turns INTERSECT from a kit-style slicer into a chromatic inst
 
 This is INTERSECT's central idea, and it's worth a concrete example.
 
-The signal chain bar at the bottom of the editor has two tabs: `GLOBAL` (sample-wide defaults) and `SLICE` (overrides for the selected slice).
+The signal chain bar at the bottom of the editor has two tabs: `SAMPLE` (sample-wide defaults) and `SLICE` (overrides for the selected slice).
 
-> **Example.** With no slice selected, set `GLOBAL → PITCH` to `+2`. Every slice in the sample now plays at +2 semitones. Now select one slice, click the `SLICE` tab, and drag its `PITCH` to `+7`. The parameter label highlights — that slice has a **lock** on `PITCH`. It plays at +7. All other slices still inherit `+2`.
+> **Example.** With no slice selected, set `SAMPLE → PITCH` to `+2`. Every slice in the sample now plays at +2 semitones. Now select one slice, click the `SLICE` tab, and drag its `PITCH` to `+7`. The parameter label highlights — that slice has a **lock** on `PITCH`. It plays at +7. All other slices still inherit `+2`.
 >
-> Change `GLOBAL → PITCH` to `0`. The locked slice still plays at `+7`; everything else now plays at `0`.
+> Change `SAMPLE → PITCH` to `0`. The locked slice still plays at `+7`; everything else now plays at `0`.
 >
 > Right-click the locked `PITCH` value (or click the highlighted parameter label) to clear the lock. The slice re-inherits the global default.
 
@@ -65,7 +65,17 @@ INTERSECT ships three time/pitch engines. Pick one per sample with `ALGO`.
 
 `SET BPM` (in the Time/Pitch module) calculates the sample's BPM from a musical duration. Pick "1 bar", "1/4 note", "1/8 note", and so on; the engine computes BPM from the selected slice's length and auto-locks the BPM value. This is the workflow when you know "this loop is 2 bars" but don't know the exact tempo.
 
-Available in both `GLOBAL` and `SLICE` scope.
+Available in both `SAMPLE` and `SLICE` scope.
+
+## Detect BPM
+
+INTERSECT can estimate a sample's tempo automatically:
+
+- **`BPM` button** on each sample block in the sample bar (left of `STEMS`). Click it to analyse that sample; a menu shows the best estimate plus half/double and other candidates — pick one to set the sample's BPM. If the clip is too short to estimate (e.g. a one-shot), a status message says so and nothing changes. Detection runs in the background; the button shows `…` while it works.
+- **`SET BPM → Detect BPM`** runs the same detection on the selected sample.
+- **Auto-detect on import** (gear menu → *Auto-Detect BPM on Import*) analyses every newly imported sample automatically and sets its BPM — no clicks, no popup. One-shots are skipped. This preference is saved with your app settings and is off by default.
+
+Each sample keeps its **own** detected BPM; slices inside a sample follow that sample's tempo unless individually locked. Detected values are undoable (Ctrl/Cmd+Z), and clearing the `SAMPLE → BPM` override restores inheritance from the plugin default.
 
 ## Filter
 

--- a/src/PluginEditor.cpp
+++ b/src/PluginEditor.cpp
@@ -462,6 +462,10 @@ void IntersectEditor::timerCallback()
     // Apply deferred non-RT parameter restores from undo/redo.
     processor.applyDeferredParamRestore();
 
+    // Surface a manual BPM-detection result as a candidates popup.
+    if (auto popup = processor.takeBpmCandidatesPopup())
+        sampleLane.showBpmCandidatesPopup (popup->sampleId, popup->bestBpm, popup->candidates);
+
     bool uiChanged = false;
     bool viewportChanged = false;
     bool fadeOverlayChanged = false;
@@ -674,6 +678,7 @@ void IntersectEditor::saveUserSettings (float scale, const juce::String& themeNa
     content << "nrpnEnabled: "  << (processor.midiEditState.enabled.load (std::memory_order_relaxed) ? "true" : "false") << "\n";
     content << "nrpnChannel: "  << processor.midiEditState.channel.load (std::memory_order_relaxed) << "\n";
     content << "nrpnBlockCc: "  << (processor.midiEditState.consumeMidiEditCc.load (std::memory_order_relaxed) ? "true" : "false") << "\n";
+    content << "autoBpmOnImport: " << (processor.autoBpmOnImport.load (std::memory_order_relaxed) ? "true" : "false") << "\n";
     content << "middleC: " << middleCOctave << "\n";
     content << "sampleBrowserVisible: " << (sampleBrowserVisible ? "true" : "false") << "\n";
     const auto browserBookmarks = sampleBrowser.getBookmarks();
@@ -744,6 +749,11 @@ void IntersectEditor::loadUserSettings()
             {
                 auto val = line.fromFirstOccurrenceOf (":", false, false).trim();
                 processor.midiEditState.consumeMidiEditCc.store (val == "true", std::memory_order_relaxed);
+            }
+            else if (line.startsWith ("autoBpmOnImport:"))
+            {
+                auto val = line.fromFirstOccurrenceOf (":", false, false).trim();
+                processor.autoBpmOnImport.store (val == "true", std::memory_order_relaxed);
             }
             else if (line.startsWith ("middleC:"))
             {

--- a/src/PluginProcessor.cpp
+++ b/src/PluginProcessor.cpp
@@ -201,6 +201,7 @@ static bool isCriticalCommand (IntersectProcessor::CommandType type)
 
         case IntersectProcessor::CmdLoadFile:
         case IntersectProcessor::CmdAppendFiles:
+        case IntersectProcessor::CmdSetSampleBpm:
         case IntersectProcessor::CmdCreateSlice:
         case IntersectProcessor::CmdDeleteSlice:
         case IntersectProcessor::CmdDeleteSessionSample:
@@ -380,6 +381,7 @@ IntersectProcessor::IntersectProcessor()
     // stemJob's use of AsyncUpdater; handleAsyncUpdate drains all three.
     stemModelDownloadJob.onTerminalState = [this] { triggerAsyncUpdate(); };
     ortBundleDownloadJob.onTerminalState = [this] { triggerAsyncUpdate(); };
+    bpmDetector.onComplete = [this] { triggerAsyncUpdate(); };
 
 	    publishUiSliceSnapshot();
 }
@@ -494,6 +496,99 @@ void IntersectProcessor::handleAsyncUpdate()
 {
     handleStemJobCompletionOnMessageThread();
     handleDownloadCompletionsOnMessageThread();
+    handleBpmDetectionCompletionsOnMessageThread();
+}
+
+void IntersectProcessor::handleBpmDetectionCompletionsOnMessageThread()
+{
+    enqueueArmedAutoBpmDetections();
+
+    auto detectorResults = bpmDetector.takeResults();
+    for (auto& r : detectorResults)
+    {
+        // Re-validate: the sample may have been deleted while detection ran.
+        if (sampleData.findSessionSampleById (r.sampleId) == nullptr)
+            continue;
+
+        const juce::String name = [this, id = r.sampleId]() -> juce::String
+        {
+            if (auto* s = sampleData.findSessionSampleById (id))
+                return s->fileName;
+            return {};
+        }();
+
+        if (r.bestBpm <= 0.0)
+        {
+            // Could not detect. Warn only for explicit manual requests; the
+            // auto-import path stays silent (one-shots never get a value).
+            if (r.manual)
+                setUiStatusMessage ("No tempo detected"
+                                    + (name.isNotEmpty() ? " for " + name : juce::String()), true);
+            continue;
+        }
+
+        if (r.manual)
+        {
+            // Defer to the candidates popup (best / half / double / others).
+            pendingBpmPopup = BpmCandidatesPopup { r.sampleId, r.bestBpm, std::move (r.candidates) };
+            markUiSnapshotDirty();
+        }
+        else
+        {
+            applyDetectedBpm (r.sampleId, r.bestBpm, /*captureUndo*/ false);
+            setUiStatusMessage ("BPM detected: " + juce::String (r.bestBpm, 2)
+                                + (name.isNotEmpty() ? " - " + name : juce::String()), false);
+        }
+    }
+}
+
+void IntersectProcessor::startBpmDetectionForSample (int sampleId, bool manual)
+{
+    auto snap = sampleData.getSnapshot();
+    const SampleData::SessionSample* sample = nullptr;
+    if (snap != nullptr)
+        for (const auto& s : snap->sessionSamples)
+            if (s.sampleId == sampleId)
+            {
+                sample = &s;
+                break;
+            }
+
+    if (sample == nullptr || sample->filePath.isEmpty())
+    {
+        if (manual)
+            setUiStatusMessage ("No sample to analyse", true);
+        return;
+    }
+
+    bpmDetector.enqueue (sampleId, sample->filePath, manual);
+    if (manual)
+        setUiStatusMessage ("Detecting BPM...", false);
+    markUiSnapshotDirty();
+}
+
+void IntersectProcessor::applyDetectedBpm (int sampleId, double bpm, bool captureUndo)
+{
+    if (bpm <= 0.0)
+        return;
+    const float rounded = juce::jlimit (20.0f, 999.0f, (float) (std::round (bpm * 100.0) / 100.0));
+
+    Command cmd;
+    cmd.type = CmdSetSampleBpm;
+    cmd.intParam1 = sampleId;
+    cmd.floatParam1 = rounded;
+    cmd.intParam2 = captureUndo ? 0 : 1;
+    pushCommand (cmd);
+    markUiSnapshotDirty();
+}
+
+std::optional<IntersectProcessor::BpmCandidatesPopup> IntersectProcessor::takeBpmCandidatesPopup()
+{
+    if (! pendingBpmPopup.has_value())
+        return std::nullopt;
+    auto out = std::move (pendingBpmPopup);
+    pendingBpmPopup.reset();
+    return out;
 }
 
 void IntersectProcessor::handleDownloadCompletionsOnMessageThread()
@@ -538,7 +633,7 @@ void IntersectProcessor::handleStemJobCompletionOnMessageThread()
             auto* old = pendingStemImport.exchange (pending, std::memory_order_acq_rel);
             delete old;
 
-            loadFilesAsync (stemResult.stemFiles, true);
+            loadFilesAsync (stemResult.stemFiles, true, /*allowAutoBpm*/ false);
             setUiStatusMessage (stemResult.warningMessage.isNotEmpty()
                                     ? stemResult.warningMessage
                                     : juce::String ("Stems imported"),
@@ -660,7 +755,13 @@ bool IntersectProcessor::enqueueUiUndoSnapshot()
         snap.numSessionSamples = juce::jmin ((int) sampleSnap->sessionSamples.size(),
                                              SampleData::kMaxSessionSamples);
         for (int i = 0; i < snap.numSessionSamples; ++i)
+        {
             snap.sessionSamples[(size_t) i] = sampleSnap->sessionSamples[(size_t) i];
+            // The decoded snapshot never carries per-sample BPM; overlay the
+            // side-table value so undo round-trips it.
+            snap.sessionSamples[(size_t) i].sampleBpm =
+                getSampleBpm (snap.sessionSamples[(size_t) i].sampleId);
+        }
     }
     snap.selectedSessionSampleId = selectedSessionSampleId.load (std::memory_order_relaxed);
     for (int i = 0; i < SliceManager::kMaxSlices; ++i)
@@ -846,7 +947,7 @@ void IntersectProcessor::loadFileAsync (const juce::File& file)
     loadFilesAsync (std::vector<juce::File> { file }, false);
 }
 
-void IntersectProcessor::loadFilesAsync (const std::vector<juce::File>& files, bool append)
+void IntersectProcessor::loadFilesAsync (const std::vector<juce::File>& files, bool append, bool allowAutoBpm)
 {
     pendingStateRestoreToken.store (0, std::memory_order_release);
     if (files.empty())
@@ -854,6 +955,7 @@ void IntersectProcessor::loadFilesAsync (const std::vector<juce::File>& files, b
 
     std::vector<juce::File> orderedFiles;
     std::vector<int> sampleIds;
+    std::vector<int> newSampleIds;  // ids of just-imported files (for auto-BPM)
 
     if (append)
     {
@@ -869,19 +971,67 @@ void IntersectProcessor::loadFilesAsync (const std::vector<juce::File>& files, b
         }
         for (const auto& file : files)
         {
+            const int id = generateSessionSampleId();
             orderedFiles.push_back (file);
-            sampleIds.push_back (generateSessionSampleId());
+            sampleIds.push_back (id);
+            newSampleIds.push_back (id);
         }
         setPendingStateFile (orderedFiles.front());
         setPendingStateFiles (orderedFiles);
-        requestSampleLoad (orderedFiles, LoadKindPreserveSlices, &sampleIds);
+        const int token = requestSampleLoad (orderedFiles, LoadKindPreserveSlices, &sampleIds);
+        armAutoBpmDetection (allowAutoBpm, token, newSampleIds);
         return;
     }
 
     orderedFiles = files;
+    // Generate ids explicitly (rather than letting requestSampleLoad assign them)
+    // so the new samples are known for auto-BPM arming.
+    sampleIds.reserve (files.size());
+    for (size_t i = 0; i < files.size(); ++i)
+    {
+        const int id = generateSessionSampleId();
+        sampleIds.push_back (id);
+        newSampleIds.push_back (id);
+    }
     setPendingStateFile (orderedFiles.front());
     setPendingStateFiles (orderedFiles);
-    requestSampleLoad (orderedFiles, LoadKindReplace);
+    const int token = requestSampleLoad (orderedFiles, LoadKindReplace, &sampleIds);
+    armAutoBpmDetection (allowAutoBpm, token, newSampleIds);
+}
+
+void IntersectProcessor::armAutoBpmDetection (bool allowAutoBpm, int loadToken,
+                                              const std::vector<int>& newSampleIds)
+{
+    if (! allowAutoBpm
+        || newSampleIds.empty()
+        || ! autoBpmOnImport.load (std::memory_order_relaxed))
+    {
+        autoBpmArmedToken.store (0, std::memory_order_release);
+        autoBpmArmedIds.clear();
+        return;
+    }
+    autoBpmArmedIds = newSampleIds;
+    autoBpmArmedToken.store (loadToken, std::memory_order_release);
+}
+
+void IntersectProcessor::enqueueArmedAutoBpmDetections()
+{
+    const int fireToken = autoBpmFireToken.exchange (0, std::memory_order_acq_rel);
+    if (fireToken == 0)
+        return;
+
+    auto snap = sampleData.getSnapshot();
+    if (snap != nullptr)
+    {
+        for (int id : autoBpmArmedIds)
+            for (const auto& s : snap->sessionSamples)
+                if (s.sampleId == id && s.filePath.isNotEmpty())
+                {
+                    bpmDetector.enqueue (id, s.filePath, /*manual*/ false);
+                    break;
+                }
+    }
+    autoBpmArmedIds.clear();
 }
 
 void IntersectProcessor::relinkFileAsync (const juce::File& file)
@@ -965,6 +1115,84 @@ StemMetadata IntersectProcessor::getStemMeta (int sampleId) const
         if (stemMetaEntries[(size_t) i].sampleId == sampleId)
             return stemMetaEntries[(size_t) i].meta;
     return {};
+}
+
+void IntersectProcessor::setSampleBpm (int sampleId, float bpm)
+{
+    if (bpm > 0.0f)
+        bpm = juce::jlimit (20.0f, 999.0f, bpm);
+    else
+        bpm = 0.0f;
+
+    const int count = sampleBpmEntryCount.load (std::memory_order_acquire);
+    for (int i = 0; i < count; ++i)
+    {
+        if (sampleBpmEntries[(size_t) i].sampleId.load (std::memory_order_relaxed) == sampleId)
+        {
+            sampleBpmEntries[(size_t) i].bpm.store (bpm, std::memory_order_relaxed);
+            return;
+        }
+    }
+
+    if (bpm <= 0.0f)
+        return;  // no entry and nothing to store
+
+    if (count >= SampleData::kMaxSessionSamples)
+    {
+        // Compact away entries whose sample no longer exists (ids are monotonic,
+        // never reused, so stale entries are permanently dead).
+        int writeIdx = 0;
+        for (int i = 0; i < count; ++i)
+        {
+            const int id = sampleBpmEntries[(size_t) i].sampleId.load (std::memory_order_relaxed);
+            if (sampleData.findSessionSampleById (id) == nullptr)
+                continue;
+            if (writeIdx != i)
+            {
+                sampleBpmEntries[(size_t) writeIdx].sampleId.store (id, std::memory_order_relaxed);
+                sampleBpmEntries[(size_t) writeIdx].bpm.store (
+                    sampleBpmEntries[(size_t) i].bpm.load (std::memory_order_relaxed),
+                    std::memory_order_relaxed);
+            }
+            ++writeIdx;
+        }
+        sampleBpmEntryCount.store (writeIdx, std::memory_order_release);
+        if (writeIdx >= SampleData::kMaxSessionSamples)
+            return;
+    }
+
+    const int idx = sampleBpmEntryCount.load (std::memory_order_acquire);
+    sampleBpmEntries[(size_t) idx].sampleId.store (sampleId, std::memory_order_relaxed);
+    sampleBpmEntries[(size_t) idx].bpm.store (bpm, std::memory_order_relaxed);
+    sampleBpmEntryCount.store (idx + 1, std::memory_order_release);
+}
+
+float IntersectProcessor::getSampleBpm (int sampleId) const
+{
+    const int count = sampleBpmEntryCount.load (std::memory_order_acquire);
+    for (int i = 0; i < count; ++i)
+        if (sampleBpmEntries[(size_t) i].sampleId.load (std::memory_order_relaxed) == sampleId)
+            return sampleBpmEntries[(size_t) i].bpm.load (std::memory_order_relaxed);
+    return 0.0f;
+}
+
+float IntersectProcessor::effectiveSampleBpm (int sampleId, float fallback) const
+{
+    const float bpm = getSampleBpm (sampleId);
+    return bpm > 0.0f ? bpm : fallback;
+}
+
+void IntersectProcessor::clearAllSampleBpm()
+{
+    sampleBpmEntryCount.store (0, std::memory_order_release);
+}
+
+float IntersectProcessor::effectiveBpmAtFrame (int frame, float fallback) const
+{
+    for (const auto& sample : sampleData.getSessionSamples())
+        if (frame >= sample.startFrame && frame < sample.startFrame + sample.numFrames)
+            return effectiveSampleBpm (sample.sampleId, fallback);
+    return fallback;
 }
 
 juce::File IntersectProcessor::getStemModelFolder() const
@@ -1587,6 +1815,7 @@ void IntersectProcessor::publishUiSliceSnapshot()
             uiSample.sampleId = sample.sampleId;
             uiSample.startSample = sample.startFrame;
             uiSample.numFrames = sample.numFrames;
+            uiSample.sampleBpm = getSampleBpm (sample.sampleId);
             uiSample.fileName.assign (sample.fileName);
         }
         else
@@ -1829,7 +2058,11 @@ UndoManager::Snapshot IntersectProcessor::makeSnapshot()
         snap.numSessionSamples = juce::jmin ((int) sampleSnap->sessionSamples.size(),
                                              SampleData::kMaxSessionSamples);
         for (int i = 0; i < snap.numSessionSamples; ++i)
+        {
             snap.sessionSamples[(size_t) i] = sampleSnap->sessionSamples[(size_t) i];
+            snap.sessionSamples[(size_t) i].sampleBpm =
+                getSampleBpm (snap.sessionSamples[(size_t) i].sampleId);
+        }
     }
     snap.selectedSessionSampleId = selectedSessionSampleId.load (std::memory_order_relaxed);
     for (int i = 0; i < SliceManager::kMaxSlices; ++i)
@@ -1874,6 +2107,14 @@ void IntersectProcessor::restoreSnapshot (const UndoManager::Snapshot& snap)
     selectedSessionSampleId.store (snap.selectedSessionSampleId, std::memory_order_relaxed);
     midiSelectsSlice.store (snap.midiSelectsSlice);
     snapToZeroCrossing.store (snap.snapToZeroCrossing);
+
+    clearAllSampleBpm();
+    for (int i = 0; i < snap.numSessionSamples; ++i)
+    {
+        const auto& sample = snap.sessionSamples[(size_t) i];
+        if (sample.sampleBpm > 0.0f)
+            setSampleBpm (sample.sampleId, sample.sampleBpm);
+    }
 
     if (! files.empty())
     {
@@ -1947,6 +2188,16 @@ void IntersectProcessor::handleCommand (const Command& cmd)
             blocksSinceGestureActivity = 0;
             break;
 
+        case CmdSetSampleBpm:
+            if (cmd.intParam2 == 0)
+            {
+                if (! gestureSnapshotCaptured)
+                    captureSnapshot();
+                gestureSnapshotCaptured = true;
+                blocksSinceGestureActivity = 0;
+            }
+            break;
+
         case CmdSetSliceBounds:
         case CmdCreateSlice:
         case CmdDeleteSlice:
@@ -2007,7 +2258,9 @@ void IntersectProcessor::handleCommand (const Command& cmd)
             if (sampleData.isLoaded())
             {
                 const auto globals = loadGlobalParamSnapshot();
-                const auto psp = makePreviewStretchParams (globals, dawBpm.load(), currentSampleRate, &sampleData);
+                auto psp = makePreviewStretchParams (globals, dawBpm.load(), currentSampleRate, &sampleData);
+                // Playback starts at frame 0; BPM resolves once at start.
+                psp.bpm = effectiveBpmAtFrame (0, psp.bpm);
                 lazyChop.start (sampleData.getNumFrames(), sliceManager, psp,
                                 snapToZeroCrossing.load(), &sampleData.getBuffer());
             }
@@ -2045,7 +2298,12 @@ void IntersectProcessor::handleCommand (const Command& cmd)
                 bool turningOn = !(s.lockMask & bit);
 
                 if (turningOn)
-                    copyGlobalToSlice (s, globals, bit);
+                {
+                    auto effGlobals = globals;
+                    if (bit == kLockBpm)
+                        effGlobals.bpm = effectiveSampleBpm (s.sampleId, globals.bpm);
+                    copyGlobalToSlice (s, effGlobals, bit);
+                }
 
                 s.lockMask ^= bit;
             }
@@ -2093,7 +2351,9 @@ void IntersectProcessor::handleCommand (const Command& cmd)
                 switch (field)
                 {
                     case FieldBpm:
-                        setFloatField (s.bpm, val, globals.bpm, kLockBpm);
+                        // Lock comparison is against the slice's inherited BPM
+                        // (its sample's BPM when set, else the default).
+                        setFloatField (s.bpm, val, effectiveSampleBpm (s.sampleId, globals.bpm), kLockBpm);
                         break;
                     case FieldPitch:
                         setFloatField (s.pitchSemitones, val, globals.pitchSemitones, kLockPitch);
@@ -2509,6 +2769,13 @@ void IntersectProcessor::handleCommand (const Command& cmd)
             // Launched from message thread via startStemSeparation(); nothing to do here.
             break;
 
+        case CmdSetSampleBpm:
+            // Ignore ids no longer in the session so a stale command can't
+            // resurrect a deleted sample's entry.
+            if (sampleData.findSessionSampleById (cmd.intParam1) != nullptr)
+                setSampleBpm (cmd.intParam1, cmd.floatParam1);
+            break;
+
         case CmdNone:
             break;
     }
@@ -2836,6 +3103,8 @@ void IntersectProcessor::processMidiEvent (const juce::MidiMessage& msg,
 
                 p.sliceIdx = sliceIdx;
                 p.sliceRootNote = s.sliceRootNote;
+                // Per-slice: slices may belong to different session samples.
+                p.globalBpm = effectiveSampleBpm (s.sampleId, globals.bpm);
                 voicePool.startVoice (voiceIdx, p, sliceManager, sampleData);
             }
         }
@@ -2926,7 +3195,8 @@ void IntersectProcessor::processBlock (juce::AudioBuffer<float>& buffer,
         else if (req >= 0 && ! lazyChop.isActive() && sampleData.isLoaded())
         {
             const auto globals = loadGlobalParamSnapshot();
-            const auto psp = makePreviewStretchParams (globals, dawBpm.load(), currentSampleRate, &sampleData);
+            auto psp = makePreviewStretchParams (globals, dawBpm.load(), currentSampleRate, &sampleData);
+            psp.bpm = effectiveBpmAtFrame (req, psp.bpm);
             voicePool.startShiftPreview (req, sampleData.getNumFrames(), psp);
         }
     }
@@ -2958,6 +3228,9 @@ void IntersectProcessor::processBlock (juce::AudioBuffer<float>& buffer,
                 const int retryToken = requestSampleLoad (files, currentLoadKind, &sampleIds);
                 if (isStateRestoreLoad)
                     pendingStateRestoreToken.store (retryToken, std::memory_order_release);
+                // Carry an armed auto-BPM detection across the sample-rate retry.
+                if (autoBpmArmedToken.load (std::memory_order_acquire) == currentToken)
+                    autoBpmArmedToken.store (retryToken, std::memory_order_release);
             }
             else
             {
@@ -3023,6 +3296,14 @@ void IntersectProcessor::processBlock (juce::AudioBuffer<float>& buffer,
 
                 if (isStateRestoreLoad)
                     pendingStateRestoreToken.store (0, std::memory_order_release);
+
+                // Fire any armed auto-BPM detection now that the samples are live.
+                if (autoBpmArmedToken.load (std::memory_order_acquire) == currentToken)
+                {
+                    autoBpmArmedToken.store (0, std::memory_order_release);
+                    autoBpmFireToken.store (currentToken, std::memory_order_release);
+                    triggerAsyncUpdate();
+                }
 
                 loadStateChanged = true;
                 uiSnapshotDirty.store (true, std::memory_order_release);
@@ -3329,7 +3610,7 @@ void IntersectProcessor::getStateInformation (juce::MemoryBlock& destData)
 
     // Optional v24 extension block for fields added without changing the base version.
     stream.writeInt (kStateExtensionMagic);
-    stream.writeInt (6);
+    stream.writeInt (7);
     stream.writeInt (numSlices);
     for (int i = 0; i < numSlices; ++i)
         stream.writeInt (sliceManager.getSlice (i).repitchMode);
@@ -3381,6 +3662,10 @@ void IntersectProcessor::getStateInformation (juce::MemoryBlock& destData)
     }
     // Extension v6: stem compute device preference
     stream.writeInt (static_cast<int> (stemComputeDevice));
+    // Extension v7: per-session-sample BPM (0 = unset → inherit defaultBpm)
+    stream.writeInt (numSessionSamples);
+    for (int i = 0; i < numSessionSamples; ++i)
+        stream.writeFloat (getSampleBpm (sampleSnap->sessionSamples[(size_t) i].sampleId));
 }
 
 void IntersectProcessor::setStateInformation (const void* data, int sizeInBytes)
@@ -3726,6 +4011,25 @@ void IntersectProcessor::setStateInformation (const void* data, int sizeInBytes)
                         stemComputeDevice = static_cast<StemComputeDevice> (juce::jlimit (0, 1, deviceInt));
                     }
                 }
+
+                if (extensionVersion >= 7)
+                {
+                    if (! requireBytes (4))
+                        return result;
+
+                    const int storedSampleBpms = juce::jlimit (0, SampleData::kMaxSessionSamples,
+                                                               trialStream.readInt());
+                    for (int i = 0; i < storedSampleBpms; ++i)
+                    {
+                        if (! requireBytes (4))
+                            return result;
+
+                        const float bpm = trialStream.readFloat();
+                        if (i < (int) result.sessionSamples.size())
+                            result.sessionSamples[(size_t) i].sampleBpm =
+                                (bpm >= 20.0f && bpm <= 999.0f) ? bpm : 0.0f;
+                    }
+                }
             }
             else
             {
@@ -3818,14 +4122,17 @@ void IntersectProcessor::setStateInformation (const void* data, int sizeInBytes)
     clearVoicesBeforeSampleSwap();
     sampleData.clear();
 
-    // Restore stem metadata from parsed session samples
+    // Restore stem metadata + per-sample BPM from parsed session samples
     stemMetaEntryCount = 0;
+    clearAllSampleBpm();
     if (! postSliceResult->sessionSamples.empty())
     {
         for (const auto& sample : postSliceResult->sessionSamples)
         {
             if (sample.stemMeta.isGenerated)
                 setStemMeta (sample.sampleId, sample.stemMeta);
+            if (sample.sampleBpm > 0.0f)
+                setSampleBpm (sample.sampleId, sample.sampleBpm);
         }
     }
 

--- a/src/PluginProcessor.h
+++ b/src/PluginProcessor.h
@@ -12,6 +12,7 @@
 #include "audio/StemModelDownloadJob.h"
 #include "audio/OrtBundleDownloadJob.h"
 #include "audio/StemSeparationJob.h"
+#include "audio/BpmDetector.h"
 #include "UndoManager.h"
 #include "params/GlobalParamSnapshot.h"
 #include "params/ParamUndoState.h"
@@ -79,6 +80,9 @@ public:
         CmdSelectSlice,
         CmdSetRootNote,
         CmdStemSeparate,
+        // intParam1 = sampleId, floatParam1 = bpm (0 clears → inherit),
+        // intParam2 = 1 suppresses undo capture (auto-detect writes).
+        CmdSetSampleBpm,
     };
 
     enum LoadKind
@@ -198,10 +202,38 @@ public:
     std::atomic<bool> pendingEndGesture { false };
 
     void loadFileAsync (const juce::File& file);
-    void loadFilesAsync (const std::vector<juce::File>& files, bool append);
+    // allowAutoBpm gates auto-detect-on-import; only genuine user imports pass
+    // true (stem-generated loads pass false).
+    void loadFilesAsync (const std::vector<juce::File>& files, bool append, bool allowAutoBpm = true);
     void relinkFileAsync (const juce::File& file);
     void reorderSessionSampleAsync (int sourceSampleId, int targetIndex);
     void deleteSessionSampleAsync (int sampleId);
+
+    // Per-sample BPM (0 = unset → inherit defaultBpm). Runtime authority is an
+    // atomic side table keyed by session sample id; SessionSample::sampleBpm is
+    // only a carrier for undo snapshots and state save/load.
+    float getSampleBpm (int sampleId) const;
+    float effectiveSampleBpm (int sampleId, float fallback) const;
+
+    // Automatic BPM detection.
+    void startBpmDetectionForSample (int sampleId, bool manual);
+    bool isBpmDetectionRunningFor (int sampleId) const { return bpmDetector.isPendingOrRunning (sampleId); }
+    // Message thread. Writes the per-sample BPM through the command FIFO.
+    // captureUndo=false suppresses the undo snapshot (auto-import writes).
+    void applyDetectedBpm (int sampleId, double bpm, bool captureUndo);
+
+    // Whether newly imported samples are auto-analysed. Persisted in
+    // settings.yaml by the editor; defaults off until settings load.
+    std::atomic<bool> autoBpmOnImport { false };
+
+    // Message thread. A manual detection result awaiting the candidates popup.
+    struct BpmCandidatesPopup
+    {
+        int sampleId = -1;
+        double bestBpm = 0.0;
+        std::vector<double> candidates;  // ranked best-first
+    };
+    std::optional<BpmCandidatesPopup> takeBpmCandidatesPopup();
     void startStemSeparation (int sampleId,
                               StemModelId modelId,
                               StemSelectionMask stemSelectionMask,
@@ -238,6 +270,7 @@ public:
             int sampleId = 0;
             int startSample = 0;
             int numFrames = 0;
+            float sampleBpm = 0.0f;  // 0 = unset (inherits defaultBpm)
             RtText<256> fileName;
         };
 
@@ -524,6 +557,38 @@ private:
     int stemMetaEntryCount = 0;
     void setStemMeta (int sampleId, const StemMetadata& meta);
     StemMetadata getStemMeta (int sampleId) const;
+
+    // Per-sample BPM side table (see public getSampleBpm). Atomic fields because
+    // the audio thread reads it per note-on while the message thread refills it
+    // during state restore. Steady-state writes go through CmdSetSampleBpm.
+    struct SampleBpmEntry
+    {
+        std::atomic<int> sampleId { -1 };
+        std::atomic<float> bpm { 0.0f };
+    };
+    std::array<SampleBpmEntry, SampleData::kMaxSessionSamples> sampleBpmEntries {};
+    std::atomic<int> sampleBpmEntryCount { 0 };
+    void setSampleBpm (int sampleId, float bpm);
+    void clearAllSampleBpm();
+    // Audio thread only (walks the active session-sample list).
+    float effectiveBpmAtFrame (int frame, float fallback) const;
+
+    BpmDetector bpmDetector;
+    void handleBpmDetectionCompletionsOnMessageThread();
+    // Manual result awaiting the editor's candidates popup. Written and read
+    // only on the message thread (handleAsyncUpdate + editor timer).
+    std::optional<BpmCandidatesPopup> pendingBpmPopup;
+
+    // Auto-detect-on-import arming. loadFilesAsync arms the new sample ids
+    // against the load token; the audio thread flags the token once the decode
+    // is applied (so the samples exist), and handleAsyncUpdate enqueues them.
+    // Only genuine user imports arm — restore/relink/reorder/stem/samplerate
+    // reloads bypass loadFilesAsync and never arm.
+    std::atomic<int> autoBpmArmedToken { 0 };   // 0 = none
+    std::atomic<int> autoBpmFireToken { 0 };    // set by audio thread on apply
+    std::vector<int> autoBpmArmedIds;           // message-thread only
+    void armAutoBpmDetection (bool allowAutoBpm, int loadToken, const std::vector<int>& newSampleIds);
+    void enqueueArmedAutoBpmDetections();
 
     // Pending stem metadata to apply after the import load completes
     struct PendingStemImport

--- a/src/audio/BpmDetector.cpp
+++ b/src/audio/BpmDetector.cpp
@@ -1,0 +1,174 @@
+#include "BpmDetector.h"
+#include "minibpm/src/MiniBpm.h"
+#include <algorithm>
+
+BpmDetector::BpmDetector()
+    : juce::Thread ("BpmDetector")
+{
+    formatManager.registerBasicFormats();
+    startThread (juce::Thread::Priority::background);
+}
+
+BpmDetector::~BpmDetector()
+{
+    signalThreadShouldExit();
+    wakeEvent.signal();
+    stopThread (2000);
+}
+
+void BpmDetector::enqueue (int sampleId, const juce::String& filePath, bool manual)
+{
+    if (sampleId < 0 || filePath.isEmpty())
+        return;
+
+    {
+        const juce::ScopedLock sl (queueLock);
+
+        auto existing = std::find_if (queue.begin(), queue.end(),
+                                      [sampleId] (const Request& q) { return q.sampleId == sampleId; });
+        if (existing != queue.end())
+        {
+            // Already queued. An auto duplicate is a no-op; a manual request
+            // upgrades the entry and moves it to the head so the popup shows.
+            if (manual)
+            {
+                queue.erase (existing);
+                queue.push_front (Request { sampleId, filePath, true });
+                wakeEvent.signal();
+            }
+            return;
+        }
+
+        Request req { sampleId, filePath, manual };
+        if (manual)
+            queue.push_front (req);
+        else
+            queue.push_back (req);
+    }
+
+    wakeEvent.signal();
+}
+
+bool BpmDetector::isPendingOrRunning (int sampleId) const
+{
+    if (activeSampleId.load (std::memory_order_acquire) == sampleId)
+        return true;
+
+    const juce::ScopedLock sl (queueLock);
+    for (const auto& r : queue)
+        if (r.sampleId == sampleId)
+            return true;
+    return false;
+}
+
+bool BpmDetector::isBusy() const
+{
+    if (activeSampleId.load (std::memory_order_acquire) >= 0)
+        return true;
+    const juce::ScopedLock sl (queueLock);
+    return ! queue.empty();
+}
+
+std::vector<BpmDetector::Result> BpmDetector::takeResults()
+{
+    const juce::ScopedLock sl (resultsLock);
+    std::vector<Result> out;
+    out.swap (results);
+    return out;
+}
+
+void BpmDetector::run()
+{
+    while (! threadShouldExit())
+    {
+        Request req;
+        bool haveReq = false;
+        {
+            const juce::ScopedLock sl (queueLock);
+            if (! queue.empty())
+            {
+                req = queue.front();
+                queue.pop_front();
+                haveReq = true;
+            }
+        }
+
+        if (! haveReq)
+        {
+            wakeEvent.wait (-1);
+            continue;
+        }
+
+        activeSampleId.store (req.sampleId, std::memory_order_release);
+        Result result = process (req);
+        activeSampleId.store (-1, std::memory_order_release);
+
+        if (threadShouldExit())
+            return;
+
+        {
+            const juce::ScopedLock sl (resultsLock);
+            results.push_back (std::move (result));
+        }
+
+        if (onComplete)
+            onComplete();
+    }
+}
+
+BpmDetector::Result BpmDetector::process (const Request& req)
+{
+    Result result;
+    result.sampleId = req.sampleId;
+    result.manual = req.manual;
+
+    std::unique_ptr<juce::AudioFormatReader> reader (
+        formatManager.createReaderFor (juce::File (req.filePath)));
+    if (reader == nullptr || reader->sampleRate <= 0.0 || reader->lengthInSamples <= 0)
+        return result;  // unreadable → bestBpm stays 0
+
+    const double lengthSeconds = (double) reader->lengthInSamples / reader->sampleRate;
+    if (lengthSeconds < kMinLengthSeconds)
+        return result;  // too short → bestBpm stays 0
+
+    breakfastquay::MiniBPM estimator ((float) reader->sampleRate);
+    estimator.setBPMRange (kMinBpm, kMaxBpm);
+
+    const int numChannels = (int) reader->numChannels;
+    constexpr int kChunk = 65536;
+    juce::AudioBuffer<float> chunkBuffer (juce::jmax (1, numChannels), kChunk);
+    std::vector<float> mono ((size_t) kChunk);
+
+    juce::int64 pos = 0;
+    const juce::int64 total = reader->lengthInSamples;
+    while (pos < total)
+    {
+        if (threadShouldExit())
+            return result;
+
+        const int n = (int) juce::jmin ((juce::int64) kChunk, total - pos);
+        chunkBuffer.clear();
+        reader->read (&chunkBuffer, 0, n, pos, true, numChannels > 1);
+
+        const float* left = chunkBuffer.getReadPointer (0);
+        if (numChannels > 1)
+        {
+            const float* right = chunkBuffer.getReadPointer (1);
+            for (int i = 0; i < n; ++i)
+                mono[(size_t) i] = (left[i] + right[i]) * 0.5f;
+        }
+        else
+        {
+            for (int i = 0; i < n; ++i)
+                mono[(size_t) i] = left[i];
+        }
+
+        estimator.process (mono.data(), n);
+        pos += n;
+    }
+
+    result.bestBpm = estimator.estimateTempo();
+    if (result.bestBpm > 0.0)
+        result.candidates = estimator.getTempoCandidates();
+    return result;
+}

--- a/src/audio/BpmDetector.h
+++ b/src/audio/BpmDetector.h
@@ -1,0 +1,82 @@
+#pragma once
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <atomic>
+#include <deque>
+#include <functional>
+#include <vector>
+
+/**
+ * Background BPM detection for session samples.
+ *
+ * A single worker thread drains a FIFO queue of detection requests, reading the
+ * audio file from disk (so a request can be queued the instant a sample is
+ * imported, without waiting for the timeline decode to finish), mixing it to
+ * mono and running the MiniBPM fixed-tempo estimator. Results are pushed to a
+ * lock-guarded vector and the owner is notified via onComplete() so it can drain
+ * them on the message thread.
+ *
+ * Requests carry a session sampleId; the owner re-validates on completion that
+ * the sample still exists before applying the detected BPM. Manual requests
+ * (user pressed the BPM button) take priority over auto-on-import requests and
+ * surface a candidates popup; auto requests apply silently.
+ */
+class BpmDetector : private juce::Thread
+{
+public:
+    struct Result
+    {
+        int sampleId = -1;
+        bool manual = false;
+        double bestBpm = 0.0;               // 0 = could not detect (too short / unreadable)
+        std::vector<double> candidates;     // ranked best-first (best == bestBpm)
+    };
+
+    BpmDetector();
+    ~BpmDetector() override;
+
+    // Message thread. Enqueue a detection request. Manual requests jump to the
+    // head of the queue; duplicate queued ids are coalesced (a manual request
+    // promotes an already-queued entry).
+    void enqueue (int sampleId, const juce::String& filePath, bool manual);
+
+    // Message thread. True while the given sample is queued or actively being
+    // processed — drives the sample-lane busy indicator.
+    bool isPendingOrRunning (int sampleId) const;
+    bool isBusy() const;
+
+    // Message thread. Drain completed results (empties the internal buffer).
+    std::vector<Result> takeResults();
+
+    // Set by the owner before first enqueue; invoked from the worker thread when
+    // a result becomes available. Typically wired to triggerAsyncUpdate().
+    std::function<void()> onComplete;
+
+    // Detection tempo range (MiniBPM default 55-190).
+    static constexpr double kMinBpm = 55.0;
+    static constexpr double kMaxBpm = 190.0;
+    // Clips shorter than this cannot yield a reliable fixed-tempo estimate.
+    static constexpr double kMinLengthSeconds = 2.0;
+
+private:
+    struct Request
+    {
+        int sampleId = -1;
+        juce::String filePath;
+        bool manual = false;
+    };
+
+    void run() override;
+    Result process (const Request& req);
+
+    juce::AudioFormatManager formatManager;
+
+    mutable juce::CriticalSection queueLock;
+    std::deque<Request> queue;
+    std::atomic<int> activeSampleId { -1 };
+    juce::WaitableEvent wakeEvent;
+
+    juce::CriticalSection resultsLock;
+    std::vector<Result> results;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (BpmDetector)
+};

--- a/src/audio/SampleData.h
+++ b/src/audio/SampleData.h
@@ -37,6 +37,7 @@ public:
         int sourceNumFrames = 0;
         double sourceSampleRate = 0.0;
         StemMetadata stemMeta;
+        float sampleBpm = 0.0f;  // 0 = unset (inherit defaultBpm); carrier for undo/state only
     };
 
     struct DecodedSample

--- a/src/ui/HeaderBar.cpp
+++ b/src/ui/HeaderBar.cpp
@@ -16,6 +16,7 @@ enum SettingsMenuItemId
     kMenuSetMidiOmni,
     kMenuMidiPrev,
     kMenuMidiNext,
+    kMenuAutoBpmOnImport,
     kMenuSponsor,
     kMenuThemeBase = 2000,
     kMenuMiddleCBase = 3000,  // +0=C3, +1=C4, +2=C5
@@ -269,6 +270,8 @@ void HeaderBar::showSettingsPopup()
     menu.addSeparator();
     menu.addSubMenu ("Middle C  C" + juce::String (currentMiddleC), middleCMenu);
     menu.addSubMenu (formatNrpnStatus (nrpnCh), nrpnMenu);
+    menu.addItem (kMenuAutoBpmOnImport, "Auto-Detect BPM on Import", true,
+                  processor.autoBpmOnImport.load (std::memory_order_relaxed));
     menu.addSubMenu ("Themes  " + currentName, themesMenu);
 
     const auto stemFolder = processor.getResolvedStemModelFolder();
@@ -401,6 +404,12 @@ void HeaderBar::showSettingsPopup()
             {
                 const int ch = processor.midiEditState.channel.load (std::memory_order_relaxed);
                 processor.midiEditState.channel.store (juce::jlimit (0, 16, ch + 1), std::memory_order_relaxed);
+                editor->saveUserSettings (scale, getTheme().name);
+            }
+            else if (result == kMenuAutoBpmOnImport)
+            {
+                const bool current = processor.autoBpmOnImport.load (std::memory_order_relaxed);
+                processor.autoBpmOnImport.store (! current, std::memory_order_relaxed);
                 editor->saveUserSettings (scale, getTheme().name);
             }
             else if (result == kMenuSponsor)

--- a/src/ui/SampleLane.cpp
+++ b/src/ui/SampleLane.cpp
@@ -81,12 +81,17 @@ std::vector<SampleLane::VisibleSample> SampleLane::buildVisibleSamples() const
         const int deleteW = juce::jmin (16, juce::jmax (12, blockW / 6));
         const int cancelW = juce::jmin (54, juce::jmax (34, blockW / 2));
         const int stemsW = jobRunning ? cancelW : juce::jmin (44, juce::jmax (18, blockW / 3));
+        const int bpmW = juce::jmin (34, juce::jmax (18, blockW / 4));
         int right = x2 - 3;
         visible.deleteBounds = { right - deleteW, buttonY, deleteW, buttonH };
         right = visible.deleteBounds.getX() - 2;
         visible.stemsBounds = { right - stemsW, buttonY, stemsW, buttonH };
-        visible.deleteBounds = visible.deleteBounds.getIntersection ({ x1 + 1, buttonY, juce::jmax (1, blockW - 2), buttonH });
-        visible.stemsBounds = visible.stemsBounds.getIntersection ({ x1 + 1, buttonY, juce::jmax (1, blockW - 2), buttonH });
+        right = visible.stemsBounds.getX() - 2;
+        visible.bpmBounds = { right - bpmW, buttonY, bpmW, buttonH };
+        const juce::Rectangle<int> clip { x1 + 1, buttonY, juce::jmax (1, blockW - 2), buttonH };
+        visible.deleteBounds = visible.deleteBounds.getIntersection (clip);
+        visible.stemsBounds = visible.stemsBounds.getIntersection (clip);
+        visible.bpmBounds = visible.bpmBounds.getIntersection (clip);
         out.push_back (std::move (visible));
     }
 
@@ -163,7 +168,7 @@ void SampleLane::paint (juce::Graphics& g)
                 labelX = end + 1;
         }
 
-        const int maxLabelRight = juce::jmin (sample.stemsBounds.getX() - 2, getWidth());
+        const int maxLabelRight = juce::jmin (sample.bpmBounds.getX() - 2, getWidth());
         const int availableLabelW = juce::jmax (1, maxLabelRight - labelX - 2);
         if (availableLabelW >= 8)
         {
@@ -208,6 +213,18 @@ void SampleLane::paint (juce::Graphics& g)
                     "X",
                     juce::Colours::black.withAlpha (0.18f),
                     getTheme().text2.withAlpha (0.86f));
+
+        if (! sample.bpmBounds.isEmpty())
+        {
+            const bool detecting = processor.isBpmDetectionRunningFor (sample.sampleId);
+            drawButton (sample.bpmBounds,
+                        detecting ? juce::String ("...")
+                                  : (sample.bpmBounds.getWidth() < 24 ? juce::String ("B")
+                                                                      : juce::String ("BPM")),
+                        detecting ? getTheme().accent.withAlpha (0.55f)
+                                  : getTheme().surface4.withAlpha (0.92f),
+                        getTheme().text2.withAlpha (0.92f));
+        }
     }
 
     // Draw stem separation progress bar on the source sample
@@ -263,6 +280,15 @@ void SampleLane::mouseDown (const juce::MouseEvent& e)
         processor.selectedSessionSampleId.store (hitId, std::memory_order_relaxed);
         processor.markUiSnapshotDirty();
         processor.deleteSessionSampleAsync (hitId);
+        repaint();
+        return;
+    }
+
+    if (it != visible.end() && ! it->bpmBounds.isEmpty() && it->bpmBounds.contains (pos))
+    {
+        processor.selectedSessionSampleId.store (hitId, std::memory_order_relaxed);
+        processor.markUiSnapshotDirty();
+        processor.startBpmDetectionForSample (hitId, /*manual*/ true);
         repaint();
         return;
     }
@@ -335,6 +361,83 @@ void SampleLane::mouseUp (const juce::MouseEvent&)
     dragTargetIndex = -1;
     dragging = false;
     repaint();
+}
+
+juce::String SampleLane::getTooltip()
+{
+    const auto pos = getMouseXYRelative();
+    const auto visible = buildVisibleSamples();
+    for (const auto& sample : visible)
+    {
+        if (! sample.bpmBounds.isEmpty() && sample.bpmBounds.contains (pos))
+            return processor.isBpmDetectionRunningFor (sample.sampleId)
+                       ? "Detecting BPM..."
+                       : "Detect BPM and set Sample BPM";
+        if (sample.stemsBounds.contains (pos))
+            return "Separate stems";
+        if (sample.deleteBounds.contains (pos))
+            return "Remove sample";
+    }
+    return {};
+}
+
+void SampleLane::showBpmCandidatesPopup (int sampleId, double bestBpm, const std::vector<double>& candidates)
+{
+    if (bestBpm <= 0.0)
+        return;
+
+    // Assemble a deduplicated, ordered candidate list: best, then half/double,
+    // then any remaining MiniBPM candidates.
+    std::vector<double> values;
+    auto addValue = [&values] (double v)
+    {
+        if (v < 20.0 || v > 999.0)
+            return;
+        const double rounded = std::round (v * 100.0) / 100.0;
+        for (double existing : values)
+            if (std::abs (existing - rounded) < 0.05)
+                return;
+        values.push_back (rounded);
+    };
+
+    addValue (bestBpm);
+    addValue (bestBpm * 2.0);
+    addValue (bestBpm * 0.5);
+    for (double c : candidates)
+        addValue (c);
+
+    juce::PopupMenu menu;
+    menu.addSectionHeader ("Detected BPM");
+    for (size_t i = 0; i < values.size(); ++i)
+    {
+        juce::String label = juce::String (values[i], 2);
+        if (i == 0)
+            label += "  (best)";
+        else if (std::abs (values[i] - std::round (bestBpm * 2.0 * 100.0) / 100.0) < 0.05)
+            label += "  (x2)";
+        else if (std::abs (values[i] - std::round (bestBpm * 0.5 * 100.0) / 100.0) < 0.05)
+            label += "  (1/2)";
+        menu.addItem ((int) i + 1, label);
+    }
+
+    // Anchor at the sample block if still visible, else at the lane.
+    juce::Rectangle<int> target = getScreenBounds();
+    const auto visible = buildVisibleSamples();
+    for (const auto& sample : visible)
+        if (sample.sampleId == sampleId && ! sample.bpmBounds.isEmpty())
+        {
+            target = localAreaToGlobal (sample.bpmBounds);
+            break;
+        }
+
+    auto* proc = &processor;
+    menu.showMenuAsync (juce::PopupMenu::Options().withTargetScreenArea (target),
+                        [proc, sampleId, values] (int result)
+                        {
+                            if (result <= 0 || result > (int) values.size())
+                                return;
+                            proc->applyDetectedBpm (sampleId, values[(size_t) (result - 1)], /*captureUndo*/ true);
+                        });
 }
 
 void SampleLane::showStemExportPanel (int sampleId)

--- a/src/ui/SampleLane.h
+++ b/src/ui/SampleLane.h
@@ -7,7 +7,8 @@ class IntersectProcessor;
 class StemExportPanel;
 class WaveformView;
 
-class SampleLane : public juce::Component
+class SampleLane : public juce::Component,
+                   public juce::TooltipClient
 {
 public:
     SampleLane (IntersectProcessor& p, WaveformView& wv);
@@ -18,8 +19,14 @@ public:
     void mouseDown (const juce::MouseEvent& e) override;
     void mouseDrag (const juce::MouseEvent& e) override;
     void mouseUp (const juce::MouseEvent& e) override;
+    juce::String getTooltip() override;
 
     bool isStemExportOpen() const { return stemExportPanel != nullptr; }
+
+    // Called from the editor timer when a manual detection completes: shows a
+    // menu of the best estimate plus half/double and other candidates, anchored
+    // at the sample's block.
+    void showBpmCandidatesPopup (int sampleId, double bestBpm, const std::vector<double>& candidates);
 
 private:
     struct VisibleSample
@@ -31,6 +38,7 @@ private:
         bool selected = false;
         juce::Colour colour;
         juce::String label;
+        juce::Rectangle<int> bpmBounds;
         juce::Rectangle<int> stemsBounds;
         juce::Rectangle<int> deleteBounds;
     };

--- a/src/ui/SignalChainBar.cpp
+++ b/src/ui/SignalChainBar.cpp
@@ -381,7 +381,12 @@ int SignalChainBar::countEffectiveModuleOverrides (Module module,
     switch (module)
     {
         case Module::TimePitch:
-            count += checkFloat (kLockBpm, slice.bpm, globals.bpm);
+        {
+            // A locked slice BPM is an override relative to its inherited value
+            // (its sample's BPM when set, else the default).
+            const float sampleBpm = processor.getSampleBpm (slice.sampleId);
+            count += checkFloat (kLockBpm, slice.bpm, sampleBpm > 0.0f ? sampleBpm : globals.bpm);
+        }
             count += checkFloat (kLockPitch, slice.pitchSemitones, globals.pitchSemitones);
             count += checkFloat (kLockCentsDetune, slice.centsDetune, globals.centsDetune);
             count += checkInt (kLockAlgorithm, slice.algorithm, globals.algorithm);
@@ -570,6 +575,21 @@ void SignalChainBar::rebuildLayout()
         : 44100.0f;
     input.selectedSlice = input.hasValidSlice ? &ui.slices[(size_t) ui.selectedSlice] : nullptr;
     input.middleCOctave = middleCOctave;
+
+    // Resolve the selected session sample's per-sample BPM (SAMPLE-tab BPM cell)
+    // and the BPM of the sample owning the selected slice (slice-scope display).
+    input.selectedSampleId = ui.selectedSessionSampleId;
+    for (int i = 0; i < ui.numSessionSamples; ++i)
+    {
+        const auto& s = ui.sessionSamples[(size_t) i];
+        if (s.sampleId == ui.selectedSessionSampleId)
+        {
+            input.hasSelectedSample = true;
+            input.selectedSampleBpm = s.sampleBpm;
+        }
+        if (input.selectedSlice != nullptr && s.sampleId == input.selectedSlice->sampleId)
+            input.selectedSliceSampleBpm = s.sampleBpm;
+    }
 
     contextTitle.clear();
     contextSubtitle.clear();
@@ -905,7 +925,7 @@ void SignalChainBar::rebuildContextBar (const LayoutInput& input)
 
         contextRow.performLayout (contextArea.toFloat());
 
-        addTabCell (toIntBounds (contextRow.items[0].currentBounds), "GLOBAL", TabTarget::Global, ! input.sliceScope, true);
+        addTabCell (toIntBounds (contextRow.items[0].currentBounds), "SAMPLE", TabTarget::Global, ! input.sliceScope, true);
         addTabCell (toIntBounds (contextRow.items[2].currentBounds), sliceTabText, TabTarget::Slice, input.sliceScope, input.hasValidSlice);
 
         contextInfoBounds = toIntBounds (contextRow.items[timeItemIndex].currentBounds);
@@ -962,7 +982,7 @@ void SignalChainBar::rebuildContextBar (const LayoutInput& input)
     contextRow.items.add (juce::FlexItem().withWidth (10.0f));  // trailing pad
     contextRow.performLayout (contextArea.toFloat());
 
-    addTabCell (toIntBounds (contextRow.items[0].currentBounds), "GLOBAL", TabTarget::Global, ! input.sliceScope, true);
+    addTabCell (toIntBounds (contextRow.items[0].currentBounds), "SAMPLE", TabTarget::Global, ! input.sliceScope, true);
     addTabCell (toIntBounds (contextRow.items[2].currentBounds), sliceTabText, TabTarget::Slice, input.sliceScope, input.hasValidSlice);
 
     contextInfoBounds = toIntBounds (contextRow.items[infoItemIndex].currentBounds);
@@ -1002,9 +1022,15 @@ void SignalChainBar::rebuildTimePitchModule (const LayoutInput& input,
     setBpmCell.isEnabled = input.sliceScope ? input.hasValidSlice : input.sampleLoaded;
     addParamCell (setBpmCell);
 
+    // A slice inherits its owner sample's BPM (when set) before the default;
+    // the SAMPLE-tab cell shows the selected sample's effective BPM.
+    const float sliceInheritedBpm = (input.selectedSliceSampleBpm > 0.0f)
+        ? input.selectedSliceSampleBpm : globals.bpm;
+    const bool sampleBpmSet = input.hasSelectedSample && input.selectedSampleBpm > 0.0f;
+    const float sampleEffectiveBpm = sampleBpmSet ? input.selectedSampleBpm : globals.bpm;
     const auto [resolvedBpm, bpmLocked] = input.sliceScope
-        ? resolveLockedValue (selectedSlice, kLockBpm, selectedSlice->bpm, globals.bpm)
-        : std::pair<float, bool> { globals.bpm, false };
+        ? resolveLockedValue (selectedSlice, kLockBpm, selectedSlice->bpm, sliceInheritedBpm)
+        : std::pair<float, bool> { sampleEffectiveBpm, false };
     const auto [resolvedPitch, pitchLocked] = input.sliceScope
         ? resolveLockedValue (selectedSlice, kLockPitch, selectedSlice->pitchSemitones, globals.pitchSemitones)
         : std::pair<float, bool> { globals.pitchSemitones, false };
@@ -1059,6 +1085,15 @@ void SignalChainBar::rebuildTimePitchModule (const LayoutInput& input,
     cell.label = "BPM";
     cell.valueText = formatTrimmed (resolvedBpm, 2);
     cell.drawTrailingDivider = true;
+    // In SAMPLE scope with a sample selected, the BPM cell edits that sample's
+    // per-sample BPM (not the shared defaultBpm parameter). The lock highlight
+    // signals an explicit per-sample value; clearing it restores inheritance.
+    if (! input.sliceScope && input.hasSelectedSample)
+    {
+        cell.isSampleBpmCell = true;
+        cell.globalParamId = {};
+        cell.isLocked = sampleBpmSet;
+    }
     addParamCell (cell);
 
     cell = {};
@@ -1760,7 +1795,7 @@ void SignalChainBar::paint (juce::Graphics& g)
         {
             g.setFont (IntersectLookAndFeel::makeFont (7.0f, true));
             g.setColour (getTheme().text0.withAlpha (0.4f));
-            g.drawText (isSliceStrip ? "SLICE" : "GLOBAL",
+            g.drawText (isSliceStrip ? "SLICE" : "SAMPLE",
                         stripBounds.getX() + 2, stripBounds.getY() + 1, 36, 10,
                         juce::Justification::centredLeft);
         }
@@ -1943,7 +1978,7 @@ void SignalChainBar::drawParamCell (juce::Graphics& g, const Cell& cell) const
 
     if (cell.valueText.isNotEmpty())
     {
-        const bool isOverride = cell.isLocked && (isSliceScopeActive() || cell.isSliceScopeCell)
+        const bool isOverride = cell.isLocked && (isSliceScopeActive() || cell.isSliceScopeCell || cell.isSampleBpmCell)
             && ! cell.isHeaderControl && ! cell.isContextInline;
         auto valueColour = getTheme().text1;
         if (! isOverride && cell.isBoolean)
@@ -1993,6 +2028,22 @@ void SignalChainBar::applyCellValue (const Cell& cell, float storedValue, bool o
         cmd.sliceIdx = processor.sliceManager.selectedSlice.load();
         processor.pushCommand (cmd);
         layoutDirty = true;
+        return;
+    }
+
+    if (cell.isSampleBpmCell)
+    {
+        const int sampleId = processor.getUiSliceSnapshot().selectedSessionSampleId;
+        if (sampleId >= 0)
+        {
+            IntersectProcessor::Command cmd;
+            cmd.type = IntersectProcessor::CmdSetSampleBpm;
+            cmd.intParam1 = sampleId;
+            cmd.floatParam1 = storedValue;
+            cmd.intParam2 = 0;  // capture undo (coalesced within a drag gesture)
+            processor.pushCommand (cmd);
+            layoutDirty = true;
+        }
         return;
     }
 
@@ -2081,13 +2132,28 @@ void SignalChainBar::showSetBpmPopup (bool sliceScope)
     menu.addItem (7, "1/4 Note");
     menu.addItem (8, "1/8 Note");
     menu.addItem (9, "1/16 Note");
+    if (! sliceScope)
+    {
+        menu.addSeparator();
+        menu.addItem (10, "Detect BPM");
+    }
 
     menu.showMenuAsync (IntersectLookAndFeel::makeEditorMenuOptions (*this, 156, 24)
                             .withTargetComponent (this),
         [this, sliceScope] (int result)
         {
-            if (result <= 0 || result > 9)
+            if (result <= 0 || result > 10)
                 return;
+
+            const int selectedSampleId = processor.getUiSliceSnapshot().selectedSessionSampleId;
+
+            // Detect BPM: hand off to the background detector (manual → popup).
+            if (result == 10)
+            {
+                if (selectedSampleId >= 0)
+                    processor.startBpmDetectionForSample (selectedSampleId, /*manual*/ true);
+                return;
+            }
 
             const float bars[] = { 0.0f, 16.0f, 8.0f, 4.0f, 2.0f, 1.0f, 0.5f, 0.25f, 0.125f, 0.0625f };
             const float barCount = bars[result];
@@ -2103,8 +2169,20 @@ void SignalChainBar::showSetBpmPopup (bool sliceScope)
             }
             else if (processor.sampleData.isLoaded())
             {
+                const auto sampleSnap = processor.sampleData.getSnapshot();
+
+                // Default to the selected session sample's extent (not the whole
+                // concatenated timeline); a selected slice overrides that.
                 int startSmp = 0;
                 int endSmp = processor.sampleData.getNumFrames();
+                if (sampleSnap != nullptr)
+                    for (const auto& s : sampleSnap->sessionSamples)
+                        if (s.sampleId == selectedSampleId)
+                        {
+                            startSmp = s.startFrame;
+                            endSmp = s.startFrame + s.numFrames;
+                            break;
+                        }
 
                 const int sel = processor.sliceManager.selectedSlice.load();
                 if (sel >= 0 && sel < processor.sliceManager.getNumSlices())
@@ -2114,18 +2192,12 @@ void SignalChainBar::showSetBpmPopup (bool sliceScope)
                     endSmp = s.endSample;
                 }
 
-                const auto sampleSnap = processor.sampleData.getSnapshot();
                 const float sampleRate = (sampleSnap != nullptr && sampleSnap->decodedSampleRate > 0.0)
                     ? (float) sampleSnap->decodedSampleRate
                     : 44100.0f;
                 const float newBpm = GrainEngine::calcStretchBpm (startSmp, endSmp, barCount, sampleRate);
-                if (auto* bpmParam = processor.apvts.getParameter (ParamIds::defaultBpm))
-                {
-                    processor.enqueueUiUndoSnapshot();
-                    bpmParam->beginChangeGesture();
-                    bpmParam->setValueNotifyingHost (bpmParam->convertTo0to1 (newBpm));
-                    bpmParam->endChangeGesture();
-                }
+                if (selectedSampleId >= 0)
+                    processor.applyDetectedBpm (selectedSampleId, newBpm, /*captureUndo*/ true);
                 layoutDirty = true;
             }
 
@@ -2413,6 +2485,29 @@ void SignalChainBar::mouseDown (const juce::MouseEvent& e)
             }
         }
 
+        // Sample-BPM override clear: restore inheritance from defaultBpm.
+        if (cell.isSampleBpmCell && cell.isLocked)
+        {
+            auto labelBounds = juce::Rectangle<int> (cell.bounds.getX() + 3, cell.bounds.getY(),
+                                                     cell.bounds.getWidth() - 6, 10);
+            if (e.mods.isPopupMenu() || labelBounds.contains (pos))
+            {
+                const int sampleId = processor.getUiSliceSnapshot().selectedSessionSampleId;
+                if (sampleId >= 0)
+                {
+                    IntersectProcessor::Command cmd;
+                    cmd.type = IntersectProcessor::CmdSetSampleBpm;
+                    cmd.intParam1 = sampleId;
+                    cmd.floatParam1 = 0.0f;  // unset → inherit
+                    cmd.intParam2 = 0;       // capture undo
+                    processor.pushCommand (cmd);
+                    layoutDirty = true;
+                }
+                repaint();
+                return;
+            }
+        }
+
         if (! cell.isEnabled || cell.isReadOnly)
             return;
 
@@ -2434,7 +2529,7 @@ void SignalChainBar::mouseDown (const juce::MouseEvent& e)
         dragStartY = pos.y;
         dragStartInteractionValue = storedToInteraction (cell, cell.currentValue);
 
-        if (cellIsSlice)
+        if (cellIsSlice || cell.isSampleBpmCell)
         {
             IntersectProcessor::Command gestureCmd;
             gestureCmd.type = IntersectProcessor::CmdBeginGesture;

--- a/src/ui/SignalChainBar.h
+++ b/src/ui/SignalChainBar.h
@@ -96,6 +96,9 @@ private:
         bool isVisuallyDimmed = false;
         bool drawTrailingDivider = false;
         bool isSliceScopeCell = false;
+        // BPM cell bound to the selected session sample's per-sample BPM (writes
+        // go through CmdSetSampleBpm, not the APVTS defaultBpm parameter).
+        bool isSampleBpmCell = false;
     };
 
     struct ModuleLayout
@@ -124,6 +127,13 @@ private:
         bool sliceScope = false;
         float sampleRate = 44100.0f;
         int middleCOctave = 4;
+        // Selected session sample and its per-sample BPM (0 = unset → inherit
+        // defaultBpm). selectedSliceSampleBpm is the BPM of the sample owning
+        // the selected slice (may differ from the selected sample).
+        int selectedSampleId = -1;
+        bool hasSelectedSample = false;
+        float selectedSampleBpm = 0.0f;
+        float selectedSliceSampleBpm = 0.0f;
     };
 
     void rebuildLayout();


### PR DESCRIPTION
## Summary

Adds automatic BPM detection to INTERSECT using the [MiniBPM](https://github.com/breakfastquay/minibpm) fixed-tempo estimator (vendored as a git submodule, GPL-2.0+ — compatible with the project's GPLv3).

Two entry points:
- **Per-sample `BPM` button** in the sample lane (left of `STEMS`). Manual detection shows a candidates popup — best estimate plus half/double and other ranked candidates — and picking one sets that sample's BPM. Collapses to `B` on narrow blocks and shows `…` while detecting.
- **Auto-Detect BPM on Import** (gear menu, persisted in `settings.yaml`, off by default): detects every newly imported sample's tempo silently. One-shots (< ~2 s) are skipped.
- **`SET BPM → Detect BPM`** menu item runs the same detection on the selected sample.

## Per-sample BPM model

Each session sample now stores its **own** BPM. Slice BPM resolution inherits `slice-locked → sample BPM → defaultBpm`, so correcting a sample's tempo instantly propagates to its non-locked slices. Detection never writes the shared `defaultBpm` parameter. The signal chain's `GLOBAL` scope tab is renamed **`SAMPLE`** and its BPM cell is rebound to the selected sample's BPM (clearing the override restores inheritance).

- Serialized as **extension block v7** — base state version stays **v24**; older builds ignore it, pre-v7 projects load with all per-sample BPMs unset (identical behavior to before).
- Detected/edited values are undoable (Ctrl/Cmd+Z).

## Implementation notes

- Detection runs on a single background `juce::Thread` (`src/audio/BpmDetector.{h,cpp}`) with a FIFO request queue (manual requests jump the queue); results are delivered on the message thread via `AsyncUpdater`. Reads audio from the file so a request can be queued at import time.
- Auto-detect fires only for genuine user imports and is excluded **structurally** from state restore, relink, reorder, sample-rate reloads, and stem-generated loads (those bypass `loadFilesAsync`).

## Verification

- `cppcheck` clean (no new warnings); Podman Ubuntu 22.04 `Intersect_VST3` build passes; `objdump` glibc check clean (no symbols newer than 2.35).
- Headless standalone screenshots: BPM button renders left of STEMS; tab reads `SAMPLE`/`SLICE`; loading a generated **120 BPM click track** and clicking BPM detects **120.00 (best)** with `240 (x2)` / `60 (1/2)` candidates; picking it sets the SAMPLE BPM cell (accent-highlighted override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)